### PR TITLE
Add support for defer directive on fragment spreads 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
   },
   "scripts": {
     "test": "npm run prettier:check && npm run lint && npm run check && npm run testonly && npm run check:ts",
-    "test:fast": "npm run check && npm run testonly && npm run check:ts",
     "test:ci": "yarn check --integrity && npm run prettier:check && npm run lint -- --no-cache && npm run check && npm run testonly:cover && npm run check:ts && npm run build",
-    "test:only": "mocha --full-trace src/**/__tests__/**/*-test.js",
-    "testonly:inspect": "mocha --full-trace --inspect-brk --inspect src/**/__tests__/**/*-test.js",
+    "testonly": "mocha --full-trace src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc npm run testonly",
     "lint": "eslint --cache --report-unused-disable-directives src resources",
     "benchmark": "node --noconcurrent_sweeping --expose-gc --predictable ./resources/benchmark.js",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   },
   "scripts": {
     "test": "npm run prettier:check && npm run lint && npm run check && npm run testonly && npm run check:ts",
+    "test:fast": "npm run check && npm run testonly && npm run check:ts",
     "test:ci": "yarn check --integrity && npm run prettier:check && npm run lint -- --no-cache && npm run check && npm run testonly:cover && npm run check:ts && npm run build",
-    "testonly": "mocha --full-trace src/**/__tests__/**/*-test.js",
+    "test:only": "mocha --full-trace src/**/__tests__/**/*-test.js",
+    "testonly:inspect": "mocha --full-trace --inspect-brk --inspect src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc npm run testonly",
     "lint": "eslint --cache --report-unused-disable-directives src resources",
     "benchmark": "node --noconcurrent_sweeping --expose-gc --predictable ./resources/benchmark.js",

--- a/src/__tests__/starWarsDeferredData.js
+++ b/src/__tests__/starWarsDeferredData.js
@@ -1,0 +1,3 @@
+// @flow strict
+
+export default {};

--- a/src/__tests__/starWarsDeferredQuery-test.js
+++ b/src/__tests__/starWarsDeferredQuery-test.js
@@ -1,0 +1,144 @@
+// @flow strict
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { graphql } from '../graphql';
+import { forAwaitEach } from 'iterall';
+
+import { StarWarsSchema } from './starWarsSchema';
+
+describe.only('Star Wars Query Tests', () => {
+  describe('Uses fragments to express more complex queries', () => {
+    it('Allows us to use a fragment to avoid duplicating content', async () => {
+      const query = `
+        query UserFragment {
+          leia: human(id: "1003") {
+            __typename
+            id
+            ...HumanFragment
+          }
+          luke: human(id: "1000") {
+            __typename
+            id
+            homePlanet
+            ...HumanFragment @defer(label: "DeferLuke")
+          }
+          han: human(id: "1002") {
+            id
+            __typename
+            name
+            ...HumanFragment @defer(label: "DeferHan")
+          }
+        }
+
+        fragment HumanFragment on Human {
+          id
+          __typename
+          name
+          homePlanet
+          friends {
+            name
+          }
+        }
+      `;
+      const result = await graphql(StarWarsSchema, query);
+      const { patches: patchesIterable, ...rest } = result;
+
+      expect(rest).to.deep.equal({
+        data: {
+          han: {
+            __typename: 'Human',
+            id: '1002',
+            name: 'Han Solo',
+            homePlanet: null,
+            friends: null,
+          },
+          luke: {
+            id: '1000',
+            __typename: 'Human',
+            name: null,
+            homePlanet: 'Tatooine',
+            friends: null,
+          },
+          leia: {
+            __typename: 'Human',
+            name: 'Leia Organa',
+            homePlanet: 'Alderaan',
+            id: '1003',
+            friends: [
+              {
+                name: 'Luke Skywalker',
+              },
+              {
+                name: 'Han Solo',
+              },
+              {
+                name: 'C-3PO',
+              },
+              {
+                name: 'R2-D2',
+              },
+            ],
+          },
+        },
+      });
+
+      const patches = [];
+
+      if (patchesIterable) {
+        await forAwaitEach(patchesIterable, patch => {
+          patches.push(patch);
+        });
+      }
+
+      expect(patches).to.have.lengthOf(2);
+      expect(patches[0]).to.deep.equal({
+        label: 'DeferLuke',
+        path: ['luke'],
+        data: {
+          id: '1000',
+          __typename: 'Human',
+          name: 'Luke Skywalker',
+          homePlanet: 'Tatooine',
+          friends: [
+            {
+              name: 'Han Solo',
+            },
+            {
+              name: 'Leia Organa',
+            },
+            {
+              name: 'C-3PO',
+            },
+            {
+              name: 'R2-D2',
+            },
+          ],
+        },
+      });
+
+      expect(patches[1]).to.deep.equal({
+        label: 'DeferHan',
+        path: ['han'],
+        data: {
+          id: '1002',
+          __typename: 'Human',
+          name: 'Han Solo',
+          homePlanet: null,
+          friends: [
+            {
+              name: 'Luke Skywalker',
+            },
+            {
+              name: 'Leia Organa',
+            },
+            {
+              name: 'R2-D2',
+            },
+          ],
+        },
+      });
+    });
+  });
+});

--- a/src/__tests__/starWarsDeferredQuery-test.js
+++ b/src/__tests__/starWarsDeferredQuery-test.js
@@ -6,9 +6,86 @@ import { describe, it } from 'mocha';
 import { graphql } from '../graphql';
 import { forAwaitEach } from 'iterall';
 
-import { StarWarsSchema } from './starWarsSchema';
+import { StarWarsSchema, StarWarsSchemaDeferEnabled } from './starWarsSchema';
 
-describe.only('Star Wars Query Tests', () => {
+describe('Star Wars Query Deferred Tests', () => {
+  describe('Compatibility', () => {
+    it('Can disable @defer and return would-be deferred data as part of initial result', async () => {
+      const query = `
+        query HeroNameQuery {
+          hero {
+            id
+            ...NameFragment @defer(label: "NameFragment")
+          }
+        }
+        fragment NameFragment on Droid {
+          id
+          name
+        }
+      `;
+      const result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({
+        data: {
+          hero: {
+            id: '2001',
+            name: 'R2-D2',
+          },
+        },
+      });
+    });
+  });
+
+  describe('Basic Queries', () => {
+    it('Can @defer fragments containing scalar types', async () => {
+      const query = `
+        query HeroNameQuery {
+          hero {
+            id
+            ...NameFragment @defer(label: "NameFragment")
+          }
+        }
+        fragment NameFragment on Droid {
+          id
+          name
+        }
+      `;
+      const result = await graphql(StarWarsSchemaDeferEnabled, query);
+      const { patches: patchesIterable, ...initial } = result;
+      expect(initial).to.deep.equal({
+        data: {
+          hero: {
+            id: '2001',
+            name: null,
+          },
+        },
+      });
+
+      const patches = [];
+
+      if (patchesIterable) {
+        await forAwaitEach(patchesIterable, patch => {
+          patches.push(patch);
+        });
+      }
+
+      expect(patches).to.have.lengthOf(1);
+      expect(patches[0]).to.deep.equal({
+        label: 'NameFragment',
+        path: ['hero'],
+        data: {
+          id: '2001',
+          name: 'R2-D2',
+        },
+      });
+    });
+  });
+
+  describe('Nested Queries', () => {});
+
+  describe('Using IDs and query parameters to refetch objects', () => {});
+
+  describe('Using aliases to change the key in the response', () => {});
+
   describe('Uses fragments to express more complex queries', () => {
     it('Allows us to use a fragment to avoid duplicating content', async () => {
       const query = `
@@ -42,7 +119,7 @@ describe.only('Star Wars Query Tests', () => {
           }
         }
       `;
-      const result = await graphql(StarWarsSchema, query);
+      const result = await graphql(StarWarsSchemaDeferEnabled, query);
       const { patches: patchesIterable, ...rest } = result;
 
       expect(rest).to.deep.equal({
@@ -138,6 +215,192 @@ describe.only('Star Wars Query Tests', () => {
             },
           ],
         },
+      });
+    });
+  });
+
+  describe('Using __typename to find the type of an object', () => {});
+
+  describe('Reporting errors raised in resolvers within deferred fragments', () => {
+    it('Correctly reports error on accessing secretBackstory', async () => {
+      const query = `
+        query HeroNameQuery {
+          hero {
+            id
+            ...SecretFragment @defer(label: "SecretFragment")
+          }
+        }
+        fragment SecretFragment on Droid {
+          name
+          secretBackstory
+        }
+      `;
+      const result = await graphql(StarWarsSchemaDeferEnabled, query);
+      const { patches: patchesIterable, ...initial } = result;
+
+      expect(initial).to.deep.equal({
+        data: {
+          hero: {
+            id: '2001',
+            name: null,
+            secretBackstory: null,
+          },
+        },
+      });
+      const patches = [];
+
+      if (patchesIterable) {
+        await forAwaitEach(patchesIterable, patch => {
+          patches.push(patch);
+        });
+      }
+      expect(patches).to.have.lengthOf(1);
+      expect(patches[0]).to.deep.equal({
+        label: 'SecretFragment',
+        path: ['hero'],
+        data: {
+          name: 'R2-D2',
+          secretBackstory: null,
+        },
+        errors: [
+          {
+            message: 'secretBackstory is secret.',
+            locations: [{ line: 10, column: 11 }],
+            path: ['hero', 'secretBackstory'],
+          },
+        ],
+      });
+    });
+
+    it('Correctly reports error on accessing secretBackstory in a list', async () => {
+      const query = `
+        query HeroNameQuery {
+          hero {
+            id
+            ...SecretFriendsFragment @defer(label: "SecretFriendsFragment")
+          }
+        }
+        fragment SecretFriendsFragment on Droid {
+          id
+          friends {
+            name
+            secretBackstory
+          }
+        }
+      `;
+      const result = await graphql(StarWarsSchemaDeferEnabled, query);
+      const { patches: patchesIterable, ...initial } = result;
+      expect(initial).to.deep.equal({
+        data: {
+          hero: {
+            id: '2001',
+            friends: null,
+          },
+        },
+      });
+      const patches = [];
+      if (patchesIterable) {
+        await forAwaitEach(patchesIterable, patch => {
+          patches.push(patch);
+        });
+      }
+      expect(patches).to.have.lengthOf(1);
+      expect(patches[0]).to.deep.equal({
+        label: 'SecretFriendsFragment',
+        path: ['hero'],
+        data: {
+          id: '2001',
+          friends: [
+            {
+              name: 'Luke Skywalker',
+              secretBackstory: null,
+            },
+            {
+              name: 'Han Solo',
+              secretBackstory: null,
+            },
+            {
+              name: 'Leia Organa',
+              secretBackstory: null,
+            },
+          ],
+        },
+        errors: [
+          {
+            message: 'secretBackstory is secret.',
+            locations: [
+              {
+                line: 12,
+                column: 13,
+              },
+            ],
+            path: ['hero', 'friends', 0, 'secretBackstory'],
+          },
+          {
+            message: 'secretBackstory is secret.',
+            locations: [
+              {
+                line: 12,
+                column: 13,
+              },
+            ],
+            path: ['hero', 'friends', 1, 'secretBackstory'],
+          },
+          {
+            message: 'secretBackstory is secret.',
+            locations: [
+              {
+                line: 12,
+                column: 13,
+              },
+            ],
+            path: ['hero', 'friends', 2, 'secretBackstory'],
+          },
+        ],
+      });
+    });
+
+    it('Correctly reports error on accessing through an alias', async () => {
+      const query = `
+        query HeroNameQuery {
+          mainHero: hero {
+            name
+            ...SecretFragment @defer(label: "SecretFragment")
+          }
+        }
+        fragment SecretFragment on Droid {
+            story: secretBackstory
+        }
+      `;
+      const result = await graphql(StarWarsSchemaDeferEnabled, query);
+      const { patches: patchesIterable, ...initial } = result;
+      expect(initial).to.deep.equal({
+        data: {
+          mainHero: {
+            name: 'R2-D2',
+            story: null,
+          },
+        },
+      });
+
+      const patches = [];
+      if (patchesIterable) {
+        await forAwaitEach(patchesIterable, patch => {
+          patches.push(patch);
+        });
+      }
+      expect(patches).to.have.lengthOf(1);
+      expect(patches[0]).to.deep.equal({
+        data: null,
+        label: 'SecretFragment',
+        errors: [
+          {
+            message: 'secretBackstory is secret.',
+            locations: [{ line: 9, column: 13 }],
+            path: ['mainHero', 'story'],
+          },
+        ],
+        path: ['mainHero', 'story'],
       });
     });
   });

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -291,4 +291,5 @@ const queryType = new GraphQLObjectType({
 export const StarWarsSchema = new GraphQLSchema({
   query: queryType,
   types: [humanType, droidType],
+  experimentalDeferFragmentSpreads: true,
 });

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -291,5 +291,10 @@ const queryType = new GraphQLObjectType({
 export const StarWarsSchema = new GraphQLSchema({
   query: queryType,
   types: [humanType, droidType],
+});
+
+export const StarWarsSchemaDeferEnabled = new GraphQLSchema({
+  query: queryType,
+  types: [humanType, droidType],
   experimentalDeferFragmentSpreads: true,
 });

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -590,7 +590,11 @@ export function collectFields(
       }
       case Kind.FRAGMENT_SPREAD: {
         const fragName = selection.name.value;
-        const deferredLabel = getDeferredNodeLabel(exeContext, selection);
+
+        const deferredLabel = exeContext.schema
+          .__experimentalDeferFragmentSpreads
+          ? getDeferredNodeLabel(exeContext, selection)
+          : '';
 
         if (!shouldIncludeNode(exeContext, selection)) {
           continue;

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   // "Enum" of Type Kinds
   TypeKind,

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -253,6 +253,7 @@ export type FieldNode = {
   +arguments?: $ReadOnlyArray<ArgumentNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet?: SelectionSetNode,
+  +deferredLabel?: string,
   ...
 };
 

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -234,6 +234,7 @@ export function createSourceEventStream(
       exeContext.operation.selectionSet,
       Object.create(null),
       Object.create(null),
+      [],
     );
     const responseNames = Object.keys(fields);
     const responseName = responseNames[0];

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -848,6 +848,21 @@ describe('Introspection', () => {
               ],
             },
             {
+              name: 'defer',
+              locations: ['FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
+              args: [
+                {
+                  defaultValue: null,
+                  name: 'if',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'Boolean',
+                    ofType: null,
+                  },
+                },
+              ],
+            },
+            {
               name: 'deprecated',
               locations: ['FIELD_DEFINITION', 'ENUM_VALUE'],
               args: [

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -860,6 +860,19 @@ describe('Introspection', () => {
                     ofType: null,
                   },
                 },
+                {
+                  defaultValue: null,
+                  name: 'label',
+                  type: {
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'String',
+                      ofType: null,
+                    },
+                  },
+                },
               ],
             },
             {

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -168,6 +168,25 @@ export const GraphQLSkipDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLDeferDirective = new GraphQLDirective({
+  name: 'defer',
+  description:
+    'Directs the executor to defer this fragment when the `if` argument is true or undefined.',
+  locations: [
+    DirectiveLocation.FRAGMENT_SPREAD,
+    DirectiveLocation.INLINE_FRAGMENT,
+  ],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: 'Defer fragment when true or undefined.',
+    },
+  },
+});
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -195,6 +214,7 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
 export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
 ]);
 

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -181,7 +181,12 @@ export const GraphQLDeferDirective = new GraphQLDirective({
   args: {
     if: {
       type: GraphQLBoolean,
-      description: 'Defer fragment when true or undefined.',
+      description: 'Deferred when true or undefined.',
+    },
+    label: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'Unique name',
+      // TODO: Add defaultValue for label?
     },
   },
 });

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -78,6 +78,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,

--- a/src/type/patch.js
+++ b/src/type/patch.js
@@ -3,8 +3,10 @@
 import { $$asyncIterator } from 'iterall';
 
 import { type ObjMap } from '../jsutils/ObjMap';
+import isObjectLike from '../jsutils/isObjectLike';
 
 import { type GraphQLError } from '../error/GraphQLError';
+import { getVariableValues } from '../execution/values';
 
 /**
  * Patch Dispatcher Definition
@@ -12,55 +14,135 @@ import { type GraphQLError } from '../error/GraphQLError';
  * A Patch Dispatcher is attached to the execution context and allows us to
  * dispatch patches dynamically and obtain an AsyncIterable that yields each
  * patch in the order that they are resolved.
+ *
+ * {
+ *   'DeferredFragment_label': {
+ *     'path,to,parent': [ Patch1, Patch2, Patch3 ]
+ *   }
+ * }
  */
-
 export class PatchDispatcher {
-  resolvers: Array<
-    ({|
-      value: ExecutionPatchResult,
-      done: boolean,
-    |}) => void,
-  >;
+  _isEmpty: boolean;
 
-  results: Array<
-    Promise<{|
-      value: ExecutionPatchResult,
-      done: boolean,
-    |}>,
-  >;
+  /**
+   * this._resolvers maps the label of the deferred fragment spread to a map that maps a
+   * string representation of the path to a singleton array with a function that returns data at that path
+   * conforming to the iterator protocol.
+   *
+   * This map is accessed to resolve sub-fields before resolving parent field.
+   *
+   * E.g.:
+   * {
+   *   'DeferredFragment_label': {
+   *     'path,to,field': [() => ({ value, done: false })]
+   *   }
+   * }
+   */
+  _resolvers: ObjMap<ObjMap<(PatchIteratorResult) => void>>;
+
+  /**
+   * this._siblings maps the label of the deferred fragment spread to an array of promises that resolve
+   * to data conforming to the iterator protocol.
+   *
+   * This map is accessed when to getting all patches, in order to bundle siblings fields to a deferred label.
+   *
+   * E.g.:
+   *
+   * {
+   *   'DeferredFragment_label': [
+   *     SiblingPromise1,
+   *     SiblingPromise2
+   *   ]
+   * }
+   */
+  _siblings: ObjMap<Array<Promise<PatchIteratorResult>>>;
+
+  /**
+   * this._children maps the label of the deferred fragment spread to a map that maps the a parent path to an array of sub-patches
+   * Children are added during the evaluating requests section of GraphQL request.
+   *
+   * E.g.:
+   * {
+   *   'DeferredFragment_label': {
+   *     'path,to,parent,field': [ChildPatch1, ChildPatch2],
+   *   }
+   * }
+   */
+  _children: ObjMap<ObjMap<Array<Patch>>>;
 
   constructor() {
-    this.resolvers = [];
-    this.results = [];
+    this._isEmpty = true;
+    this._resolvers = Object.create(null);
+    this._siblings = Object.create(null);
+    this._children = Object.create(null);
   }
 
-  dispatch(patch: Patch): void {
-    patch.then(({ patchResult, subPatches }) => {
+  addChild(patch: Patch, label: string, path: string) {
+    setValue(this._children, patch, label, path);
+  }
+
+  dispatch(patch: Patch, label: string, path: string): void {
+    if (this._isEmpty) {
+      this._isEmpty = false;
+    }
+    patch.then(({ result }) => {
       // Queue patches for sub-fields before resolving parent
-      if (subPatches) {
-        for (const subPatch of subPatches) {
-          this.dispatch(subPatch);
+      const children = getValue(this._children, label, path);
+      if (children) {
+        for (const child of children) {
+          this.dispatch(child, label, path);
         }
       }
-      const resolver = this.resolvers.shift();
-      if (resolver) {
-        resolver({ value: patchResult, done: false });
+      const resolver = getValue(this._resolvers, label, path);
+      // TODO: Rethink getValue() pattern if it's gonna create an odd singleton
+      if (resolver && resolver[0]) {
+        resolver[0]({ value: result, done: false });
       }
     });
-    this.results.push(
-      new Promise<{| value: ExecutionPatchResult, done: boolean |}>(resolve => {
-        this.resolvers.push(resolve);
-      }),
-    );
+
+    const result = new Promise<PatchIteratorResult>(resolve => {
+      setValue(this._resolvers, resolve, label, path);
+    });
+    setValue(this._siblings, result, label);
   }
 
   /* TODO: Flow doesn't support symbols as keys:
      https://github.com/facebook/flow/issues/3258 */
-  getAsyncIterable(): AsyncIterable<ExecutionPatchResult> {
-    const self = this;
+  getPatches(): AsyncIterable<ExecutionPatchResult> | null {
+    if (this._isEmpty) {
+      return null;
+    }
+    const results = Object.keys(this._siblings).map(key => {
+      const promise = Promise.all(this._siblings[key]).then(values => {
+        let commonPath = [];
+        // TODO: This reduce here is some jankiness, values should probably be an asyncIterable as well?
+        let data = values.reduce((acc, val) => {
+          const { value } = val;
+          const { path, data } = value;
+
+          commonPath = getCommonPath(path, commonPath);
+          return applyPatch(acc, path, data);
+        }, {});
+
+        commonPath.forEach(pathEl => {
+          data = data[pathEl];
+        });
+
+        return {
+          value: {
+            path: commonPath,
+            label: key,
+            data: data,
+          },
+          done: false,
+        };
+      });
+      return Promise.resolve(promise);
+    });
+
     return ({
       next() {
-        return self.results.shift() || this.return();
+        return results.shift() || this.return();
       },
       return() {
         return Promise.resolve({ value: undefined, done: true });
@@ -72,14 +154,105 @@ export class PatchDispatcher {
   }
 }
 
+/**
+ * Retrives up to two keys from nested map.
+ */
+function getValue(map: ObjMap<any>, key1: string, key2?: string) {
+  let value = undefined;
+  value = map[key1];
+  if ((Array.isArray(value) || isObjectLike(value)) && key2) {
+    value = value[key2];
+  }
+  return value;
+}
+
+/**
+ * Sets value at up to two keys on map.
+ */
+function setValue(
+  map: ObjMap<any>,
+  value: any,
+  key1: string,
+  key2?: string,
+): mixed {
+  const isDeepObject = !!key2;
+  if (!map[key1]) {
+    map[key1] = isDeepObject ? {} : [];
+  }
+  if (!isDeepObject) {
+    map[key1].push(value);
+    return;
+  }
+  if (!map[key1][key2]) {
+    map[key1][key2] = [];
+  }
+  map[key1][key2].push(value);
+}
+
+/**
+ * Recursively applies patch data to existing data at the provided path.
+ */
+// TODO: Get rid of "any" types on arguments
+function applyPatch(
+  prevData: any,
+  path: $ReadOnlyArray<string | number>,
+  data: any,
+) {
+  const [nextPath, ...rest] = path;
+  let nextData = data;
+  let nextPrevData = undefined;
+
+  if (rest && rest.length) {
+    nextPrevData =
+      prevData && prevData[nextPath] ? prevData[nextPath] : prevData;
+    nextData = applyPatch(nextPrevData, rest, data);
+  }
+
+  return {
+    ...prevData,
+    [nextPath]: nextData,
+  };
+}
+
+/**
+ * Given two paths, returns the common path strings
+ * Path 1: ['viewer', 'person', 'name']
+ * Path 2: ['viewer', 'person', 'id']
+ * Common Path: ['viewer', 'person']
+ */
+function getCommonPath(
+  path: $ReadOnlyArray<string | number>,
+  commonPath: Array<string | number>,
+): Array<string | number> {
+  if (!commonPath || (commonPath && !commonPath.length)) {
+    return [...path];
+  }
+  return path
+    .map((pathElement, i) => {
+      if (commonPath[i] === pathElement) {
+        return pathElement;
+      }
+    })
+    .filter(Boolean);
+}
+
+// TODO: Bleh... I don't love this name
+type PatchIteratorResult = {|
+  value: ExecutionPatchResult,
+  done: boolean,
+|};
+
 export type ExecutionPatchResult = {
   errors?: $ReadOnlyArray<GraphQLError>,
   data?: ObjMap<mixed> | null,
   path: $ReadOnlyArray<string | number>,
+  label: string,
   ...
 };
 
 export type Patch = Promise<{|
-  patchResult: ExecutionPatchResult,
-  subPatches?: Array<Patch>,
+  label: string,
+  path: string,
+  result: ExecutionPatchResult,
+  // children?: Array<Patch>,
 |}>;

--- a/src/type/patch.js
+++ b/src/type/patch.js
@@ -6,19 +6,15 @@ import { type ObjMap } from '../jsutils/ObjMap';
 import isObjectLike from '../jsutils/isObjectLike';
 
 import { type GraphQLError } from '../error/GraphQLError';
-import { getVariableValues } from '../execution/values';
 
 /**
  * Patch Dispatcher Definition
  *
  * A Patch Dispatcher is attached to the execution context and allows us to
  * dispatch patches dynamically and obtain an AsyncIterable that yields each
- * patch in the order that they are resolved.
+ * patch in the order that they are resolved, where each patch represents the
+ * data for a deferred fragment spread.
  *
- * {
- *   'DeferredFragment_label': {
- *     'path,to,parent': [ Patch1, Patch2, Patch3 ]
- *   }
  * }
  */
 export class PatchDispatcher {
@@ -44,7 +40,7 @@ export class PatchDispatcher {
    * this._siblings maps the label of the deferred fragment spread to an array of promises that resolve
    * to data conforming to the iterator protocol.
    *
-   * This map is accessed when to getting all patches, in order to bundle siblings fields to a deferred label.
+   * This map is accessed when getting all patches to bundle siblings fields to a deferred label.
    *
    * E.g.:
    *
@@ -58,13 +54,14 @@ export class PatchDispatcher {
   _siblings: ObjMap<Array<Promise<PatchIteratorResult>>>;
 
   /**
-   * this._children maps the label of the deferred fragment spread to a map that maps the a parent path to an array of sub-patches
-   * Children are added during the evaluating requests section of GraphQL request.
+   * this._children maps the label of the deferred fragment spread to a map that maps the
+   * parent path to an array of sub-patches. Children are added during the evaluating
+   * requests section of a GraphQL request.
    *
    * E.g.:
    * {
    *   'DeferredFragment_label': {
-   *     'path,to,parent,field': [ChildPatch1, ChildPatch2],
+   *     'path,to,parent,field': [ { patch: ChildPatch1, path: 'path,to,child,field' } ],
    *   }
    * }
    */
@@ -77,8 +74,8 @@ export class PatchDispatcher {
     this._children = Object.create(null);
   }
 
-  addChild(patch: Patch, label: string, path: string) {
-    setValue(this._children, patch, label, path);
+  deferDispatch(patch: Patch, label: string, parentPath: string, path: string) {
+    setValue(this._children, { patch, path }, label, parentPath);
   }
 
   dispatch(patch: Patch, label: string, path: string): void {
@@ -90,11 +87,11 @@ export class PatchDispatcher {
       const children = getValue(this._children, label, path);
       if (children) {
         for (const child of children) {
-          this.dispatch(child, label, path);
+          const { patch: childPatch, path: childPath } = child;
+          this.dispatch(childPatch, label, childPath);
         }
       }
       const resolver = getValue(this._resolvers, label, path);
-      // TODO: Rethink getValue() pattern if it's gonna create an odd singleton
       if (resolver && resolver[0]) {
         resolver[0]({ value: result, done: false });
       }
@@ -113,30 +110,51 @@ export class PatchDispatcher {
       return null;
     }
     const results = Object.keys(this._siblings).map(key => {
-      const promise = Promise.all(this._siblings[key]).then(values => {
-        let commonPath = [];
-        // TODO: This reduce here is some jankiness, values should probably be an asyncIterable as well?
-        let data = values.reduce((acc, val) => {
-          const { value } = val;
-          const { path, data } = value;
+      // TODO: Revisit "nested promise" logic
+      // Nested promises needed because siblings are added asynchronously as
+      // patches for sub-fields are resolved. When `getPatches()` is called in execute,
+      // only the parent patches are present; however, since they are the last patches to resolve
+      // all siblings will have been added once the outer `Promise.all` resolves.
+      const promise = Promise.all(this._siblings[key]).then(() =>
+        Promise.all(this._siblings[key]).then(values => {
+          let pathIntersection = [];
+          let patchErrors = [];
 
-          commonPath = getCommonPath(path, commonPath);
-          return applyPatch(acc, path, data);
-        }, {});
+          // TODO: Use asyncIterable instead of reduce here or should this logic
+          // be applied when adding patches to siblings instead of after the fact?
+          let patchData = values.reduce((acc, val) => {
+            const { value } = val;
+            const { path, data, errors } = value;
 
-        commonPath.forEach(pathEl => {
-          data = data[pathEl];
-        });
+            if (errors && errors.length !== 0) {
+              patchErrors = [...patchErrors, ...errors];
+            }
 
-        return {
-          value: {
-            path: commonPath,
-            label: key,
-            data: data,
-          },
-          done: false,
-        };
-      });
+            pathIntersection = getPathIntersection(path, pathIntersection);
+
+            return applyPatch(acc, path, data);
+          }, {});
+
+          // Set data on patch at path intersection
+          pathIntersection.forEach(pathIntersectionEl => {
+            patchData = patchData[pathIntersectionEl];
+          });
+
+          const response =
+            patchErrors.length === 0
+              ? { data: patchData }
+              : { data: patchData, errors: patchErrors };
+
+          return {
+            value: {
+              path: pathIntersection,
+              label: key,
+              ...response,
+            },
+            done: false,
+          };
+        }),
+      );
       return Promise.resolve(promise);
     });
 
@@ -158,9 +176,9 @@ export class PatchDispatcher {
  * Retrives up to two keys from nested map.
  */
 function getValue(map: ObjMap<any>, key1: string, key2?: string) {
-  let value = undefined;
+  let value;
   value = map[key1];
-  if ((Array.isArray(value) || isObjectLike(value)) && key2) {
+  if ((Array.isArray(value) || isObjectLike(value)) && Boolean(key2)) {
     value = value[key2];
   }
   return value;
@@ -175,7 +193,7 @@ function setValue(
   key1: string,
   key2?: string,
 ): mixed {
-  const isDeepObject = !!key2;
+  const isDeepObject = Boolean(key2);
   if (!map[key1]) {
     map[key1] = isDeepObject ? {} : [];
   }
@@ -192,7 +210,6 @@ function setValue(
 /**
  * Recursively applies patch data to existing data at the provided path.
  */
-// TODO: Get rid of "any" types on arguments
 function applyPatch(
   prevData: any,
   path: $ReadOnlyArray<string | number>,
@@ -200,12 +217,20 @@ function applyPatch(
 ) {
   const [nextPath, ...rest] = path;
   let nextData = data;
-  let nextPrevData = undefined;
+  let nextPrevData;
 
   if (rest && rest.length) {
     nextPrevData =
       prevData && prevData[nextPath] ? prevData[nextPath] : prevData;
     nextData = applyPatch(nextPrevData, rest, data);
+  }
+
+  if (Array.isArray(prevData)) {
+    prevData[nextPath] = {
+      ...prevData[nextPath],
+      ...nextData,
+    };
+    return prevData;
   }
 
   return {
@@ -215,28 +240,29 @@ function applyPatch(
 }
 
 /**
- * Given two paths, returns the common path strings
- * Path 1: ['viewer', 'person', 'name']
- * Path 2: ['viewer', 'person', 'id']
- * Common Path: ['viewer', 'person']
+ * Given two paths, returns ther intersection
+ * E.g.
+ * Path 1: ['hero', 'name']
+ * Path 2: ['hero', 'homePlanet']
+ * Path Intersection: ['hero']
  */
-function getCommonPath(
-  path: $ReadOnlyArray<string | number>,
-  commonPath: Array<string | number>,
+function getPathIntersection(
+  path1: $ReadOnlyArray<string | number>,
+  path2: $ReadOnlyArray<string | number>,
 ): Array<string | number> {
-  if (!commonPath || (commonPath && !commonPath.length)) {
-    return [...path];
+  if (!path2 || (path2 && !path2.length)) {
+    return [...path1];
   }
-  return path
+  return path1
     .map((pathElement, i) => {
-      if (commonPath[i] === pathElement) {
+      if (path2[i] === pathElement) {
         return pathElement;
       }
+      return undefined;
     })
     .filter(Boolean);
 }
 
-// TODO: Bleh... I don't love this name
 type PatchIteratorResult = {|
   value: ExecutionPatchResult,
   done: boolean,
@@ -254,5 +280,4 @@ export type Patch = Promise<{|
   label: string,
   path: string,
   result: ExecutionPatchResult,
-  // children?: Array<Patch>,
 |}>;

--- a/src/type/patch.js
+++ b/src/type/patch.js
@@ -1,0 +1,85 @@
+// @flow strict
+
+import { $$asyncIterator } from 'iterall';
+
+import { type ObjMap } from '../jsutils/ObjMap';
+
+import { type GraphQLError } from '../error/GraphQLError';
+
+/**
+ * Patch Dispatcher Definition
+ *
+ * A Patch Dispatcher is attached to the execution context and allows us to
+ * dispatch patches dynamically and obtain an AsyncIterable that yields each
+ * patch in the order that they are resolved.
+ */
+
+export class PatchDispatcher {
+  resolvers: Array<
+    ({|
+      value: ExecutionPatchResult,
+      done: boolean,
+    |}) => void,
+  >;
+
+  results: Array<
+    Promise<{|
+      value: ExecutionPatchResult,
+      done: boolean,
+    |}>,
+  >;
+
+  constructor() {
+    this.resolvers = [];
+    this.results = [];
+  }
+
+  dispatch(patch: Patch): void {
+    patch.then(({ patchResult, subPatches }) => {
+      // Queue patches for sub-fields before resolving parent
+      if (subPatches) {
+        for (const subPatch of subPatches) {
+          this.dispatch(subPatch);
+        }
+      }
+      const resolver = this.resolvers.shift();
+      if (resolver) {
+        resolver({ value: patchResult, done: false });
+      }
+    });
+    this.results.push(
+      new Promise<{| value: ExecutionPatchResult, done: boolean |}>(resolve => {
+        this.resolvers.push(resolve);
+      }),
+    );
+  }
+
+  /* TODO: Flow doesn't support symbols as keys:
+     https://github.com/facebook/flow/issues/3258 */
+  getAsyncIterable(): AsyncIterable<ExecutionPatchResult> {
+    const self = this;
+    return ({
+      next() {
+        return self.results.shift() || this.return();
+      },
+      return() {
+        return Promise.resolve({ value: undefined, done: true });
+      },
+      [$$asyncIterator]() {
+        return this;
+      },
+    }: any);
+  }
+}
+
+export type ExecutionPatchResult = {
+  errors?: $ReadOnlyArray<GraphQLError>,
+  data?: ObjMap<mixed> | null,
+  path: $ReadOnlyArray<string | number>,
+  ...
+};
+
+export type Patch = Promise<{|
+  patchResult: ExecutionPatchResult,
+  subPatches?: Array<Patch>,
+|}>;

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -135,6 +135,8 @@ export class GraphQLSchema {
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
   // Referenced by validateSchema().
   __allowedLegacyNames: $ReadOnlyArray<string>;
+  // Referenced by execute()
+  __experimentalDeferFragmentSpreads: boolean;
 
   constructor(config: GraphQLSchemaConfig): void {
     // If this schema was built from a source known to be valid, then it may be
@@ -167,6 +169,8 @@ export class GraphQLSchema {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes;
 
+    this.__experimentalDeferFragmentSpreads =
+      config.experimentalDeferFragmentSpreads || false;
     this.__allowedLegacyNames = config.allowedLegacyNames || [];
     this._queryType = config.query;
     this._mutationType = config.mutation;
@@ -313,6 +317,18 @@ export type GraphQLSchemaValidationOptions = {|
    * This option is provided to ease adoption and will be removed in v15.
    */
   allowedLegacyNames?: ?$ReadOnlyArray<string>,
+
+  /**
+   *
+   * EXPERIMENTAL:
+   *
+   * If enabled, processed fields from fragment spreads with @defer directive
+   * initially resolve to null and the respective data is returned in patches after
+   * the initial result from the synchronous query.
+   *
+   * Default: false
+   */
+  experimentalDeferFragmentSpreads?: boolean,
 |};
 
 export type GraphQLSchemaConfig = {|

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -15,6 +15,7 @@ import {
   assertDirective,
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
 } from '../../type/directives';
 import {
@@ -182,12 +183,13 @@ describe('Schema Builder', () => {
     expect(cycleSDL(sdl, { commentDescriptions: true })).to.equal(sdl);
   });
 
-  it('Maintains @skip & @include', () => {
+  it('Maintains @skip, @include & @defer', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(3);
+    expect(schema.getDirectives()).to.have.lengthOf(4);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
+    expect(schema.getDirective('defer')).to.equal(GraphQLDeferDirective);
     expect(schema.getDirective('deprecated')).to.equal(
       GraphQLDeprecatedDirective,
     );
@@ -197,27 +199,30 @@ describe('Schema Builder', () => {
     const schema = buildSchema(`
       directive @skip on FIELD
       directive @include on FIELD
+      directive @defer on FIELD
       directive @deprecated on FIELD_DEFINITION
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(3);
+    expect(schema.getDirectives()).to.have.lengthOf(4);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
     );
+    expect(schema.getDirective('defer')).to.not.equal(GraphQLDeferDirective);
     expect(schema.getDirective('deprecated')).to.not.equal(
       GraphQLDeprecatedDirective,
     );
   });
 
-  it('Adding directives maintains @skip & @include', () => {
+  it('Adding directives maintains @skip, @include & @defer', () => {
     const schema = buildSchema(`
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
+    expect(schema.getDirective('defer')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
   });
 

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -6,6 +6,7 @@ import { describe, it } from 'mocha';
 import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
 } from '../../type/directives';
@@ -742,7 +743,11 @@ describe('findBreakingChanges', () => {
     const oldSchema = new GraphQLSchema({});
 
     const newSchema = new GraphQLSchema({
-      directives: [GraphQLSkipDirective, GraphQLIncludeDirective],
+      directives: [
+        GraphQLSkipDirective,
+        GraphQLIncludeDirective,
+        GraphQLDeferDirective,
+      ],
     });
 
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -520,6 +520,14 @@ describe('Type System Printer', () => {
         """Skipped when true."""
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      
+      """
+      Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
+      """
+      directive @defer(
+        """Defer fragment when true or undefined."""
+        if: Boolean
+      ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       """Marks an element of a GraphQL schema as no longer supported."""
       directive @deprecated(
@@ -751,6 +759,12 @@ describe('Type System Printer', () => {
         # Skipped when true.
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      
+      # Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
+      directive @defer(
+        # Defer fragment when true or undefined.
+        if: Boolean
+      ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       # Marks an element of a GraphQL schema as no longer supported.
       directive @deprecated(

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -525,8 +525,11 @@ describe('Type System Printer', () => {
       Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
       """
       directive @defer(
-        """Defer fragment when true or undefined."""
+        """Deferred when true or undefined."""
         if: Boolean
+
+        """Unique name"""
+        label: String!
       ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       """Marks an element of a GraphQL schema as no longer supported."""
@@ -762,8 +765,11 @@ describe('Type System Printer', () => {
       
       # Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
       directive @defer(
-        # Defer fragment when true or undefined.
+        # Deferred when true or undefined.
         if: Boolean
+
+        # Unique name
+        label: String!
       ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       # Marks an element of a GraphQL schema as no longer supported.

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -51,6 +51,7 @@ import {
   GraphQLDirective,
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
 } from '../type/directives';
 import {
@@ -165,6 +166,10 @@ export function buildASTSchema(
 
   if (!directives.some(directive => directive.name === 'include')) {
     directives.push(GraphQLIncludeDirective);
+  }
+
+  if (!directives.some(directive => directive.name === 'defer')) {
+    directives.push(GraphQLDeferDirective);
   }
 
   if (!directives.some(directive => directive.name === 'deprecated')) {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -11,6 +11,7 @@ import {
   GraphQLDirective,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
 } from '../../type/directives';
 import {
   GraphQLInt,
@@ -335,6 +336,7 @@ export const testSchema = new GraphQLSchema({
   directives: [
     GraphQLIncludeDirective,
     GraphQLSkipDirective,
+    GraphQLDeferDirective,
     new GraphQLDirective({
       name: 'onQuery',
       locations: ['QUERY'],


### PR DESCRIPTION
At [1stdibs](https://www.1stdibs.com/), our GraphQL server is built on top of [Apollo Server](https://github.com/apollographql/apollo-server). We were first introduced to the concept of the `@defer` directive through an [Apollo blog post](https://blog.apollographql.com/introducing-defer-in-apollo-server-f6797c4e9d6e) detailing an [experimental implementation](https://github.com/apollographql/apollo-server/pull/1287). We attempted to resurrect this initiative by creating an [up-to-date pull request](https://github.com/apollographql/apollo-server/pull/2181) (in hopes of that getting merged); however, it became clear to us over time that support for a `@defer` directive would occur only if it would make its way into the GraphQL spec. There has been discussion on this [issue](https://github.com/graphql/graphql-spec/issues/269) to add `@defer` to the spec, but it seems it's still in it's infancy! 

This pull request is a proposal for a Relay compatible `@defer` directive. The main distinction between the Relay implementation of `@defer` and that of Apollo's is that the `@defer` directive is supported on a fragment spread instead of on an individual field. This is a feature we are very passionate about at 1stdibs and would be interested in working with contributors in any way possible!

---
**The information below will not be included in the official PR off of the 1stdibs fork.**

**Questions**
- `getCommonPath` works under the assumption that `id` or `__typename` will always exist on the for every given patch. When I tried returning a patch without these fields and integrating with Relay experimental, it could not property resolve the patch.

  It _seems_  from looking at Relay unit tests that one or both of these fields are always on the payload even if they are missing from the query: https://github.com/facebook/relay/blob/master/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js#L831. Is this assumption true? 

- In that vein, returning redundant data seems necessary to properly resolving patches e.g. if both a field is requested in non-deferred and deferred fragment, the deferred fragment will return this field even though it already is present on the page. Is this assumption correct or is there a way around this? My original implementation stripped out redundant fields, but I got warnings (errors?) from Relay that data was missing.

**Todo**
- [x] Handle errors appropriately on deferred fragments
- [ ] Increase test coverage for deferred fragments
  - [x] Add coverage for error handling
  - [ ] Mirror test case coverage in `StarWarsQuery-test`
- [x] Put deferred support behind feature flag
- [ ] Sign CLA
- [ ] Update README