### PR TITLE
Add labels to info

### DIFF
--- a/src/execution/__tests__/defer-test.js
+++ b/src/execution/__tests__/defer-test.js
@@ -1,0 +1,320 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
+import { parse } from '../../language/parser';
+
+import { GraphQLID, GraphQLString } from '../../type/scalars';
+import { GraphQLSchema } from '../../type/schema';
+import { GraphQLObjectType, GraphQLList } from '../../type/definition';
+
+import { execute } from '../execute';
+
+const friendType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+  },
+  name: 'Friend',
+});
+
+const friends = [
+  { name: 'Han', id: 2 },
+  { name: 'Leia', id: 3 },
+  { name: 'C-3PO', id: 4 },
+];
+
+const heroType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    errorField: {
+      type: GraphQLString,
+      resolve: () => {
+        throw new Error('bad');
+      },
+    },
+    friends: {
+      type: new GraphQLList(friendType),
+      resolve: () => friends,
+    },
+  },
+  name: 'Hero',
+});
+
+const hero = { name: 'Luke', id: 1 };
+
+const query = new GraphQLObjectType({
+  fields: {
+    hero: {
+      type: heroType,
+      resolve: () => hero,
+    },
+  },
+  name: 'Query',
+});
+
+async function complete(document, options) {
+  const schema = new GraphQLSchema({
+    query,
+    experimentalDefer: options?.experimentalDefer ?? true,
+  });
+
+  const result = await execute({
+    schema,
+    document,
+    rootValue: {},
+  });
+
+  if (isAsyncIterable(result)) {
+    const results = [];
+    for await (const patch of result) {
+      results.push(patch);
+    }
+    console.log(JSON.stringify(results, null, 2));
+    return results;
+  }
+  return result;
+}
+
+describe('Execute: defer directive', () => {
+  it('Should ignore @defer if experimental defer is not enabled', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document, { experimentalDefer: false });
+
+    expect(result).to.deep.equal({
+      data: {
+        hero: {
+          id: '1',
+          name: 'Luke',
+        },
+      },
+    });
+  });
+  it('Can still query fields when experimental defer is enabled', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: {
+        hero: {
+          id: '1',
+          name: 'Luke',
+        },
+      },
+    });
+  });
+  it('Can defer fragments containing scalar types', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
+      }
+      fragment NameFragment on Hero {
+        id
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '1',
+          name: 'Luke',
+        },
+        path: ['hero'],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can disable defer using if argument', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(if: false)
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: {
+        hero: {
+          id: '1',
+          name: 'Luke',
+        },
+      },
+    });
+  });
+  it('Can defer fragments containing on the top level Query field', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        ...QueryFragment @defer(label: "DeferQuery")
+      }
+      fragment QueryFragment on Query {
+        hero {
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {},
+        hasNext: true,
+      },
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        path: [],
+        label: 'DeferQuery',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can defer a fragment within an already deferred fragment', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...TopFragment @defer(label: "DeferTop")
+        }
+      }
+      fragment TopFragment on Hero {
+        name
+        ...NestedFragment @defer(label: "DeferNested")
+      }
+      fragment NestedFragment on Hero {
+        friends {
+          name
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+        },
+        path: ['hero'],
+        label: 'DeferNested',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['hero'],
+        label: 'DeferTop',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can defer an inline fragment', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ... on Hero @defer(label: "InlineDeferred") {
+            name
+          }
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: { hero: { id: '1' } },
+        hasNext: true,
+      },
+      {
+        data: { name: 'Luke' },
+        path: ['hero'],
+        label: 'InlineDeferred',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles errors thrown in deferred fragments', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
+      }
+      fragment NameFragment on Hero {
+        errorField
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: { hero: { id: '1' } },
+        hasNext: true,
+      },
+      {
+        data: { errorField: null },
+        path: ['hero'],
+        errors: [
+          {
+            message: 'bad',
+            locations: [{ line: 9, column: 9 }],
+            path: ['hero', 'errorField'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+});

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import inspect from '../../jsutils/inspect';
 import invariant from '../../jsutils/invariant';
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
 
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
@@ -283,6 +284,7 @@ describe('Execute: Handles basic execution tasks', () => {
       'returnType',
       'parentType',
       'path',
+      'labels',
       'schema',
       'fragments',
       'rootValue',
@@ -367,6 +369,188 @@ describe('Execute: Handles basic execution tasks', () => {
         },
       },
     });
+  });
+
+  it('populates labels array with labels from nested defer fragments', async () => {
+    let labels;
+    const someObject = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve(_val, _args, _ctx, info) {
+            labels = info.labels;
+          },
+        },
+      },
+    });
+    const someUnion = new GraphQLUnionType({
+      name: 'SomeUnion',
+      types: [someObject],
+      resolveType() {
+        return 'SomeObject';
+      },
+    });
+    const testType = new GraphQLObjectType({
+      name: 'SomeQuery',
+      fields: {
+        test: {
+          type: new GraphQLNonNull(
+            new GraphQLList(new GraphQLNonNull(someUnion)),
+          ),
+        },
+      },
+    });
+    const schema = new GraphQLSchema({
+      query: testType,
+      experimentalDefer: true,
+    });
+    const rootValue = { test: [{}] };
+    const document = parse(`
+      query {
+        ... on SomeQuery @defer(label: "Label1") {
+          l1: test {
+            ... on SomeObject @defer(label: "Label2") {
+              l2: test
+            }
+          }
+        }  
+      }
+    `);
+
+    const result = await execute({ schema, document, rootValue });
+    const patches = [];
+
+    /* istanbul ignore else  - if result is not an asyncIterable, tests will fail as expected */
+    if (isAsyncIterable(result)) {
+      for await (const patch of result) {
+        patches.push(patch);
+      }
+    }
+
+    expect(labels).to.deep.equal(['Label1', 'Label2']);
+  });
+
+  it('populates labels array with undefined when necessary', async () => {
+    let labels;
+    const someObject = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve(_val, _args, _ctx, info) {
+            labels = info.labels;
+          },
+        },
+      },
+    });
+    const someUnion = new GraphQLUnionType({
+      name: 'SomeUnion',
+      types: [someObject],
+      resolveType() {
+        return 'SomeObject';
+      },
+    });
+    const testType = new GraphQLObjectType({
+      name: 'SomeQuery',
+      fields: {
+        test: {
+          type: new GraphQLNonNull(
+            new GraphQLList(new GraphQLNonNull(someUnion)),
+          ),
+        },
+      },
+    });
+    const schema = new GraphQLSchema({
+      query: testType,
+      experimentalDefer: true,
+    });
+    const rootValue = { test: [{}] };
+    const document = parse(`
+      query {
+        ... on SomeQuery @defer {
+          l1: test {
+            ... on SomeObject @defer(label: "SomeLabel") {
+              l2: test
+            }
+          }
+        }  
+      }
+    `);
+
+    const result = await execute({ schema, document, rootValue });
+    const patches = [];
+
+    /* istanbul ignore else  - if result is not an asyncIterable, tests will fail as expected */
+    if (isAsyncIterable(result)) {
+      for await (const patch of result) {
+        patches.push(patch);
+      }
+    }
+
+    expect(labels).to.deep.equal([undefined, 'SomeLabel']);
+  });
+
+  it('does not populate labels array with nested labels that do not fork execution', async () => {
+    const collectedLabels = [];
+    const someObject = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve(_val, _args, _ctx, info) {
+            collectedLabels.push(info.labels);
+          },
+        },
+      },
+    });
+    const someUnion = new GraphQLUnionType({
+      name: 'SomeUnion',
+      types: [someObject],
+      resolveType() {
+        return 'SomeObject';
+      },
+    });
+    const testType = new GraphQLObjectType({
+      name: 'SomeQuery',
+      fields: {
+        test: {
+          type: new GraphQLNonNull(
+            new GraphQLList(new GraphQLNonNull(someUnion)),
+          ),
+        },
+      },
+    });
+    const schema = new GraphQLSchema({
+      query: testType,
+      experimentalDefer: true,
+    });
+    const rootValue = { test: [{}] };
+    const document = parse(`
+      query {
+        test {
+          ... on SomeObject @defer(label: "SomeLabel") {
+            test1: test
+            ... on SomeObject @defer(label: "AnotherLabel") {
+              test2: test
+            }
+          }
+        }  
+      }
+    `);
+
+    const result = await execute({ schema, document, rootValue });
+    const patches = [];
+
+    /* istanbul ignore else  - if result is not an asyncIterable, tests will fail as expected */
+    if (isAsyncIterable(result)) {
+      for await (const patch of result) {
+        patches.push(patch);
+      }
+    }
+
+    expect(patches.length).to.equal(3);
+    expect(collectedLabels).to.deep.equal([['AnotherLabel'], ['SomeLabel']]);
   });
 
   it('threads root value context correctly', () => {

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -63,6 +63,39 @@ describe('Execute: Accepts any iterable as list value', () => {
       ],
     });
   });
+
+  it('Accepts an AsyncGenerator function as a List value', async () => {
+    async function* yieldAsyncItems() {
+      yield await 'two';
+      yield await 4;
+      yield await false;
+    }
+    const listField = yieldAsyncItems();
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', 'false'] },
+    });
+  });
+
+  it('Handles an AsyncGenerator function that throws', async () => {
+    async function* yieldAsyncItemsError() {
+      yield await 'two';
+      yield await 4;
+      throw new Error('bad');
+    }
+    const listField = yieldAsyncItemsError();
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', null] },
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 2],
+        },
+      ],
+    });
+  });
 });
 
 describe('Execute: Handles list nullability', () => {

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -9,7 +9,8 @@ import { GraphQLNonNull, GraphQLObjectType } from '../../type/definition';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
-import type { ExecutionResult } from '../execute';
+import type { ExecutionResult, AsyncExecutionResult } from '../execute';
+
 import { execute, executeSync } from '../execute';
 
 const syncError = new Error('sync');
@@ -107,7 +108,10 @@ const schema = buildSchema(`
 function executeQuery(
   query: string,
   rootValue: mixed,
-): ExecutionResult | Promise<ExecutionResult> {
+):
+  | ExecutionResult
+  | AsyncIterable<AsyncExecutionResult>
+  | Promise<ExecutionResult | AsyncIterable<AsyncExecutionResult>> {
   return execute({ schema, document: parse(query), rootValue });
 }
 

--- a/src/execution/__tests__/stream-test.js
+++ b/src/execution/__tests__/stream-test.js
@@ -1,0 +1,559 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
+import { parse } from '../../language/parser';
+
+import { GraphQLID, GraphQLString } from '../../type/scalars';
+import { GraphQLSchema } from '../../type/schema';
+import { GraphQLObjectType, GraphQLList } from '../../type/definition';
+
+import { execute } from '../execute';
+
+const friendType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+  },
+  name: 'Friend',
+});
+
+const friends = [
+  { name: 'Luke', id: 1 },
+  { name: 'Han', id: 2 },
+  { name: 'Leia', id: 3 },
+];
+
+const query = new GraphQLObjectType({
+  fields: {
+    scalarList: {
+      type: new GraphQLList(GraphQLString),
+      resolve: () => ['apple', 'banana', 'coconut'],
+    },
+    asyncList: {
+      type: new GraphQLList(friendType),
+      resolve: () => friends.map((f) => Promise.resolve(f)),
+    },
+    asyncListError: {
+      type: new GraphQLList(friendType),
+      resolve: () =>
+        friends.map((f, i) => {
+          if (i === 1) {
+            return Promise.reject(new Error('bad'));
+          }
+          return Promise.resolve(f);
+        }),
+    },
+    asyncIterableList: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        for (const friend of friends) {
+          yield friend;
+        }
+      },
+    },
+    asyncIterableError: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        yield friends[0];
+        throw new Error('bad');
+      },
+    },
+    asyncIterableListDelayedClose: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        for (const friend of friends) {
+          yield friend;
+        }
+        await new Promise((r) => setTimeout(r, 1));
+      },
+    },
+  },
+  name: 'Query',
+});
+
+async function complete(document, options) {
+  const schema = new GraphQLSchema({
+    query,
+    experimentalDefer: true,
+    experimentalStream: options?.experimentalStream ?? true,
+  });
+
+  const result = await execute({
+    schema,
+    document,
+    rootValue: {},
+  });
+
+  if (isAsyncIterable(result)) {
+    const results = [];
+    for await (const patch of result) {
+      results.push(patch);
+    }
+    return results;
+  }
+  return result;
+}
+
+describe('Execute: stream directive', () => {
+  it('Should ignore @stream if experimental stream is not enabled', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+    const result = await complete(document, { experimentalStream: false });
+
+    expect(result).to.deep.equal({
+      data: { scalarList: ['apple', 'banana', 'coconut'] },
+    });
+  });
+  it('Can still query list field when experimental stream is enabled', async () => {
+    const document = parse('{ scalarList }');
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: { scalarList: ['apple', 'banana', 'coconut'] },
+    });
+  });
+  it('Can stream a list field', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          scalarList: [],
+        },
+        hasNext: true,
+      },
+      {
+        data: 'apple',
+        path: ['scalarList', 0],
+        hasNext: true,
+      },
+      {
+        data: 'banana',
+        path: ['scalarList', 1],
+        hasNext: true,
+      },
+      {
+        data: 'coconut',
+        path: ['scalarList', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Returns label from stream directive', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 1, label: "scalar-stream") }',
+    );
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        hasNext: true,
+      },
+      {
+        data: 'banana',
+        path: ['scalarList', 1],
+        label: 'scalar-stream',
+        hasNext: true,
+      },
+      {
+        data: 'coconut',
+        path: ['scalarList', 2],
+        label: 'scalar-stream',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can disable @stream using if argument', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 0, if: false) }',
+    );
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: { scalarList: ['apple', 'banana', 'coconut'] },
+    });
+  });
+  it('Can stream a field that returns a list of promises', async () => {
+    const document = parse(`
+      query { 
+        asyncList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncList', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises before initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncListError @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncListError', 1],
+          },
+        ],
+        data: {
+          asyncListError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            null,
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncListError', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncListError @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncListError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: null,
+        path: ['asyncListError', 1],
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncListError', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncListError', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream a field that returns an async iterable', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncIterableList', 2],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles error thrown in async iterable before initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableError @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal({
+      errors: [
+        {
+          message: 'bad',
+          locations: [
+            {
+              line: 3,
+              column: 9,
+            },
+          ],
+          path: ['asyncIterableError', 1],
+        },
+      ],
+      data: {
+        asyncIterableError: [
+          {
+            name: 'Luke',
+            id: '1',
+          },
+          null,
+        ],
+      },
+    });
+  });
+  it('Handles error thrown in async iterable after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableError @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: null,
+        path: ['asyncIterableError', 1],
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncIterableError', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can @defer fields that are resolved after async iterable is complete', async () => {
+    const document = parse(`
+    query { 
+      asyncIterableList @stream(initialCount: 1, label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableList: [
+            {
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['asyncIterableList', 0],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '2',
+        },
+        path: ['asyncIterableList', 1],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '3',
+        },
+        path: ['asyncIterableList', 2],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableList', 1],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+        },
+        path: ['asyncIterableList', 2],
+        label: 'DeferName',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can @defer fields that are resolved before async iterable is complete', async () => {
+    const document = parse(`
+    query { 
+      asyncIterableListDelayedClose @stream(initialCount: 1, label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableListDelayedClose: [
+            {
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['asyncIterableListDelayedClose', 0],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '2',
+        },
+        path: ['asyncIterableListDelayedClose', 1],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '3',
+        },
+        path: ['asyncIterableListDelayedClose', 2],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableListDelayedClose', 1],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+        },
+        path: ['asyncIterableListDelayedClose', 2],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+});

--- a/src/execution/__tests__/sync-test.js
+++ b/src/execution/__tests__/sync-test.js
@@ -43,6 +43,7 @@ describe('Execute: synchronously when possible', () => {
         },
       },
     }),
+    experimentalDefer: true,
   });
 
   it('does not return a Promise for initial errors', () => {
@@ -103,6 +104,24 @@ describe('Execute: synchronously when possible', () => {
 
     it('throws if encountering async execution', () => {
       const doc = 'query Example { syncField, asyncField }';
+      expect(() => {
+        executeSync({
+          schema,
+          document: parse(doc),
+          rootValue: 'rootValue',
+        });
+      }).to.throw('GraphQL execution failed to complete synchronously.');
+    });
+
+    it('throws if encountering AsyncIterable execution', () => {
+      const doc = `
+        query Example {
+          ...asyncFrag @defer(label: "deferLabel")
+        }
+        fragment asyncFrag on Query {
+          syncField
+        }
+      `;
       expect(() => {
         executeSync({
           schema,

--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -44,6 +44,7 @@ export interface ExecutionContext {
  *
  *   - `errors` is included when any errors occurred as a non-empty array.
  *   - `data` is the result of a successful execution of the query.
+ *   - `hasNext` is true if a future payload is expected.
  *   - `extensions` is reserved for adding non-standard properties.
  */
 export interface ExecutionResult<
@@ -53,6 +54,7 @@ export interface ExecutionResult<
   errors?: ReadonlyArray<GraphQLError>;
   // TS_SPECIFIC: TData. Motivation: https://github.com/graphql/graphql-js/pull/2490#issuecomment-639154229
   data?: TData | null;
+  hasNext?: boolean;
   extensions?: TExtensions;
 }
 
@@ -65,6 +67,30 @@ export interface FormattedExecutionResult<
   data?: TData | null;
   extensions?: TExtensions;
 }
+
+/**
+ * The result of an asynchronous GraphQL patch.
+ *
+ *   - `errors` is included when any errors occurred as a non-empty array.
+ *   - `data` is the result of the additional asynchronous data.
+ *   - `path` is the location of data.
+ *   - `hasNext` is true if a future payload is expected.
+ *   - `label` is the label provided to @defer or @stream.
+ *   - `extensions` is reserved for adding non-standard properties.
+ */
+export interface ExecutionPatchResult<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+> {
+  errors?: ReadonlyArray<GraphQLError>;
+  data?: TData | null;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  hasNext: boolean;
+  extensions?: TExtensions;
+}
+
+export type AsyncExecutionResult = ExecutionResult | ExecutionPatchResult;
 
 export interface ExecutionArgs {
   schema: GraphQLSchema;

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -451,7 +451,9 @@ function executeOperation(
       exeContext.dispatcher.addFields(
         label,
         path,
-        executeFields(exeContext, type, rootValue, path, patchFields, errors),
+        executeFields(exeContext, type, rootValue, path, patchFields, errors, [
+          label,
+        ]),
         errors,
       );
     }
@@ -519,6 +521,7 @@ function executeFields(
   path: Path | void,
   fields: ObjMap<Array<FieldNode>>,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<ObjMap<mixed>> {
   const results = Object.create(null);
   let containsPromise = false;
@@ -533,6 +536,7 @@ function executeFields(
       fieldNodes,
       fieldPath,
       errors,
+      labels,
     );
 
     if (result !== undefined) {
@@ -818,6 +822,7 @@ function resolveField(
   fieldNodes: $ReadOnlyArray<FieldNode>,
   path: Path,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<mixed> {
   const fieldNode = fieldNodes[0];
   const fieldName = fieldNode.name.value;
@@ -836,6 +841,7 @@ function resolveField(
     fieldNodes,
     parentType,
     path,
+    labels,
   );
 
   // Get the resolve function, regardless of if its result is normal or abrupt (error).
@@ -867,6 +873,7 @@ function resolveField(
           path,
           resolved,
           errors,
+          labels,
         ),
       );
     } else {
@@ -878,6 +885,7 @@ function resolveField(
         path,
         result,
         errors,
+        labels,
       );
     }
 
@@ -917,6 +925,7 @@ export function buildResolveInfo(
   fieldNodes: $ReadOnlyArray<FieldNode>,
   parentType: GraphQLObjectType,
   path: Path,
+  labels?: $ReadOnlyArray<string | void>,
 ): GraphQLResolveInfo {
   // The resolve function's optional fourth argument is a collection of
   // information about the current execution state.
@@ -926,6 +935,7 @@ export function buildResolveInfo(
     returnType: fieldDef.type,
     parentType,
     path,
+    labels,
     schema: exeContext.schema,
     fragments: exeContext.fragments,
     rootValue: exeContext.rootValue,
@@ -989,6 +999,7 @@ function completeValue(
   path: Path,
   result: mixed,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<mixed> {
   // If result is an Error, throw a located error.
   if (result instanceof Error) {
@@ -1006,6 +1017,7 @@ function completeValue(
       path,
       result,
       errors,
+      labels,
     );
     if (completed === null) {
       throw new Error(
@@ -1030,6 +1042,7 @@ function completeValue(
       path,
       result,
       errors,
+      labels,
     );
   }
 
@@ -1050,6 +1063,7 @@ function completeValue(
       path,
       result,
       errors,
+      labels,
     );
   }
 
@@ -1064,6 +1078,7 @@ function completeValue(
       path,
       result,
       errors,
+      labels,
     );
   }
 
@@ -1089,6 +1104,7 @@ function completeAsyncIteratorValue(
   completedResults: Array<mixed>,
   iterator: AsyncIterator<mixed>,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): Promise<$ReadOnlyArray<mixed>> {
   const fieldPath = addPath(path, index, undefined);
   const stream = getStreamValues(exeContext, fieldNodes);
@@ -1107,6 +1123,7 @@ function completeAsyncIteratorValue(
           fieldPath,
           value,
           errors,
+          labels,
         ),
       );
 
@@ -1125,6 +1142,7 @@ function completeAsyncIteratorValue(
           fieldNodes,
           info,
           itemType,
+          labels,
         );
         return completedResults;
       }
@@ -1139,6 +1157,7 @@ function completeAsyncIteratorValue(
         completedResults,
         iterator,
         errors,
+        labels,
       );
     },
     (error) => {
@@ -1168,6 +1187,7 @@ function completeListValue(
   path: Path,
   result: mixed,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<$ReadOnlyArray<mixed>> {
   const itemType = returnType.ofType;
 
@@ -1184,6 +1204,7 @@ function completeListValue(
       [],
       iterator,
       errors,
+      labels,
     );
   }
 
@@ -1218,6 +1239,7 @@ function completeListValue(
           fieldNodes,
           info,
           itemType,
+          labels,
         );
         return;
       }
@@ -1231,6 +1253,7 @@ function completeListValue(
             itemPath,
             resolved,
             errors,
+            labels,
           ),
         );
       } else {
@@ -1242,6 +1265,7 @@ function completeListValue(
           itemPath,
           item,
           errors,
+          labels,
         );
       }
 
@@ -1303,6 +1327,7 @@ function completeAbstractValue(
   path: Path,
   result: mixed,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<ObjMap<mixed>> {
   const resolveTypeFn = returnType.resolveType ?? exeContext.typeResolver;
   const contextValue = exeContext.contextValue;
@@ -1325,6 +1350,7 @@ function completeAbstractValue(
         path,
         result,
         errors,
+        labels,
       ),
     );
   }
@@ -1344,6 +1370,7 @@ function completeAbstractValue(
     path,
     result,
     errors,
+    labels,
   );
 }
 
@@ -1390,6 +1417,7 @@ function completeObjectValue(
   path: Path,
   result: mixed,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<ObjMap<mixed>> {
   // If there is an isTypeOf predicate function, call it with the
   // current result. If isTypeOf returns false, then raise an error rather
@@ -1409,6 +1437,7 @@ function completeObjectValue(
           path,
           result,
           errors,
+          labels,
         );
       });
     }
@@ -1425,6 +1454,7 @@ function completeObjectValue(
     path,
     result,
     errors,
+    labels,
   );
 }
 
@@ -1446,6 +1476,7 @@ function collectAndExecuteSubfields(
   path: Path,
   result: mixed,
   errors?: Array<GraphQLError>,
+  labels?: $ReadOnlyArray<string | void>,
 ): PromiseOrValue<ObjMap<mixed>> {
   // Collect sub-fields to execute to complete this value.
   const { fields: subFieldNodes, patches: subPatches } = collectSubfields(
@@ -1461,6 +1492,7 @@ function collectAndExecuteSubfields(
     path,
     subFieldNodes,
     errors,
+    labels,
   );
 
   for (const subPatch of subPatches) {
@@ -1476,6 +1508,7 @@ function collectAndExecuteSubfields(
         path,
         subPatchFieldNodes,
         subPatchErrors,
+        labels ? [...labels, label] : [label],
       ),
       subPatchErrors,
     );
@@ -1672,6 +1705,7 @@ export class Dispatcher {
     fieldNodes: $ReadOnlyArray<FieldNode>,
     info: GraphQLResolveInfo,
     itemType: GraphQLOutputType,
+    labels?: $ReadOnlyArray<string | void>,
   ): void {
     const errors = [];
     this._subsequentPayloads.push(
@@ -1685,6 +1719,7 @@ export class Dispatcher {
             path,
             resolved,
             errors,
+            labels,
           ),
         )
         // Note: we don't rely on a `catch` method, but we do expect "thenable"
@@ -1715,6 +1750,7 @@ export class Dispatcher {
     fieldNodes: $ReadOnlyArray<FieldNode>,
     info: GraphQLResolveInfo,
     itemType: GraphQLOutputType,
+    labels?: $ReadOnlyArray<string | void>,
   ): void {
     const fieldPath = addPath(path, index);
     const patchErrors = [];
@@ -1733,6 +1769,7 @@ export class Dispatcher {
             fieldNodes,
             info,
             itemType,
+            labels,
           );
           return {
             value: createPatchResult(
@@ -1744,6 +1781,7 @@ export class Dispatcher {
                 fieldPath,
                 data,
                 patchErrors,
+                labels,
               ),
               label,
               fieldPath,

--- a/src/execution/index.d.ts
+++ b/src/execution/index.d.ts
@@ -8,6 +8,8 @@ export {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execute';
 
 export { getDirectiveValues } from './values';

--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -11,6 +11,8 @@ export type {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execute';
 
 export { getDirectiveValues } from './values';

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -1,5 +1,6 @@
 import type { PromiseOrValue } from './jsutils/PromiseOrValue';
 import isPromise from './jsutils/isPromise';
+import isAsyncIterable from './jsutils/isAsyncIterable';
 
 import type { Source } from './language/source';
 import { parse } from './language/parser';
@@ -13,7 +14,10 @@ import type {
 import type { GraphQLSchema } from './type/schema';
 import { validateSchema } from './type/validate';
 
-import type { ExecutionResult } from './execution/execute';
+import type {
+  ExecutionResult,
+  AsyncExecutionResult,
+} from './execution/execute';
 import { execute } from './execution/execute';
 
 /**
@@ -65,7 +69,10 @@ export type GraphQLArgs = {|
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   typeResolver?: ?GraphQLTypeResolver<any, any>,
 |};
-declare function graphql(GraphQLArgs, ..._: []): Promise<ExecutionResult>;
+declare function graphql(
+  GraphQLArgs,
+  ..._: []
+): Promise<ExecutionResult | AsyncIterable<AsyncExecutionResult>>;
 /* eslint-disable no-redeclare */
 declare function graphql(
   schema: GraphQLSchema,
@@ -76,7 +83,7 @@ declare function graphql(
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   typeResolver?: ?GraphQLTypeResolver<any, any>,
-): Promise<ExecutionResult>;
+): Promise<ExecutionResult | AsyncIterable<AsyncExecutionResult>>;
 export function graphql(
   argsOrSchema,
   source,
@@ -153,14 +160,16 @@ export function graphqlSync(
         });
 
   // Assert that the execution was synchronous.
-  if (isPromise(result)) {
+  if (isPromise(result) || isAsyncIterable(result)) {
     throw new Error('GraphQL execution failed to complete synchronously.');
   }
 
   return result;
 }
 
-function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
+function graphqlImpl(
+  args: GraphQLArgs,
+): PromiseOrValue<ExecutionResult | AsyncIterable<AsyncExecutionResult>> {
   const {
     schema,
     source,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -300,6 +300,8 @@ export {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execution/index';
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // "Enum" of Type Kinds

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // "Enum" of Type Kinds
@@ -290,6 +291,8 @@ export type {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execution/index';
 
 export { subscribe, createSourceEventStream } from './subscription/index';

--- a/src/jsutils/isAsyncIterable.js
+++ b/src/jsutils/isAsyncIterable.js
@@ -1,0 +1,17 @@
+import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
+
+/**
+ * Returns true if the provided object implements the AsyncIterator protocol via
+ * either implementing a `Symbol.asyncIterator` or `"@@asyncIterator"` method.
+ */
+declare function isAsyncIterable(value: mixed): boolean %checks(value instanceof
+  AsyncIterable);
+
+// eslint-disable-next-line no-redeclare
+export default function isAsyncIterable(maybeAsyncIterable) {
+  if (maybeAsyncIterable == null || typeof maybeAsyncIterable !== 'object') {
+    return false;
+  }
+
+  return typeof maybeAsyncIterable[SYMBOL_ASYNC_ITERATOR] === 'function';
+}

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -1,6 +1,5 @@
-import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
-
 import inspect from '../jsutils/inspect';
+import isAsyncIterable from '../jsutils/isAsyncIterable';
 import { addPath, pathToArray } from '../jsutils/Path';
 
 import { GraphQLError } from '../error/GraphQLError';
@@ -158,7 +157,7 @@ function subscribeImpl(
     // Note: Flow can't refine isAsyncIterable, so explicit casts are used.
     isAsyncIterable(resultOrStream)
       ? mapAsyncIterator(
-          ((resultOrStream: any): AsyncIterable<mixed>),
+          resultOrStream,
           mapSourceToResponse,
           reportGraphQLError,
         )
@@ -289,24 +288,10 @@ function executeSubscription(
             `Received: ${inspect(eventStream)}.`,
         );
       }
-
-      // Note: isAsyncIterable above ensures this will be correct.
-      return ((eventStream: any): AsyncIterable<mixed>);
+      return eventStream;
     },
     (error) => {
       throw locatedError(error, fieldNodes, pathToArray(path));
     },
   );
-}
-
-/**
- * Returns true if the provided object implements the AsyncIterator protocol via
- * either implementing a `Symbol.asyncIterator` or `"@@asyncIterator"` method.
- */
-function isAsyncIterable(maybeAsyncIterable: mixed): boolean {
-  if (maybeAsyncIterable == null || typeof maybeAsyncIterable !== 'object') {
-    return false;
-  }
-
-  return typeof maybeAsyncIterable[SYMBOL_ASYNC_ITERATOR] === 'function';
 }

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -156,11 +156,11 @@ function subscribeImpl(
   return sourcePromise.then((resultOrStream) =>
     // Note: Flow can't refine isAsyncIterable, so explicit casts are used.
     isAsyncIterable(resultOrStream)
-      ? mapAsyncIterator(
+      ? ((mapAsyncIterator(
           resultOrStream,
           mapSourceToResponse,
           reportGraphQLError,
-        )
+        ): any): AsyncIterator<ExecutionResult>)
       : ((resultOrStream: any): ExecutionResult),
   );
 }
@@ -233,11 +233,12 @@ function executeSubscription(
 ): Promise<AsyncIterable<mixed>> {
   const { schema, operation, variableValues, rootValue } = exeContext;
   const type = getOperationRootType(schema, operation);
-  const fields = collectFields(
+  const { fields } = collectFields(
     exeContext,
     type,
     operation.selectionSet,
     Object.create(null),
+    [],
     Object.create(null),
   );
   const responseNames = Object.keys(fields);

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -479,6 +479,7 @@ export interface GraphQLResolveInfo {
   readonly returnType: GraphQLOutputType;
   readonly parentType: GraphQLObjectType;
   readonly path: Path;
+  readonly labels?: Maybe<Array<Maybe<string>>>;
   readonly schema: GraphQLSchema;
   readonly fragments: { [key: string]: FragmentDefinitionNode };
   readonly rootValue: any;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -948,6 +948,7 @@ export type GraphQLResolveInfo = {|
   +returnType: GraphQLOutputType,
   +parentType: GraphQLObjectType,
   +path: Path,
+  +labels?: $ReadOnlyArray<string | void>,
   +schema: GraphQLSchema,
   +fragments: ObjMap<FragmentDefinitionNode>,
   +rootValue: mixed,

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -17,7 +17,7 @@ import type {
   GraphQLArgument,
   GraphQLFieldConfigArgumentMap,
 } from './definition';
-import { GraphQLString, GraphQLBoolean } from './scalars';
+import { GraphQLString, GraphQLBoolean, GraphQLInt } from './scalars';
 import { argsToArgsConfig, GraphQLNonNull } from './definition';
 
 /**
@@ -186,6 +186,30 @@ export const GraphQLDeferDirective = new GraphQLDirective({
     label: {
       type: GraphQLString,
       description: 'Unique name',
+    },
+  },
+});
+
+/**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLStreamDirective = new GraphQLDirective({
+  name: 'stream',
+  description:
+    'Directs the executor to stream plural fields when the `if` argument is true or undefined.',
+  locations: [DirectiveLocation.FIELD],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: 'Stream when true or undefined.',
+    },
+    label: {
+      type: GraphQLString,
+      description: 'Unique name',
+    },
+    initialCount: {
+      type: GraphQLNonNull(GraphQLInt),
+      description: 'Number of items to return immediately',
     },
   },
 });

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -168,6 +168,29 @@ export const GraphQLSkipDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLDeferDirective = new GraphQLDirective({
+  name: 'defer',
+  description:
+    'Directs the executor to defer this fragment when the `if` argument is true or undefined.',
+  locations: [
+    DirectiveLocation.FRAGMENT_SPREAD,
+    DirectiveLocation.INLINE_FRAGMENT,
+  ],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: 'Deferred when true or undefined.',
+    },
+    label: {
+      type: GraphQLString,
+      description: 'Unique name',
+    },
+  },
+});
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -77,6 +77,7 @@ export {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -76,6 +76,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -120,6 +120,18 @@ export interface GraphQLSchemaValidationOptions {
    * Default: false
    */
   assumeValid?: boolean;
+
+  /**
+   *
+   * EXPERIMENTAL:
+   *
+   * If enabled, processed fields from fragment spreads with @defer directive
+   * are not returned from the initial query and the respective data is returned
+   * in patches after the initial result from the synchronous query.
+   *
+   * Default: false
+   */
+  experimentalDefer?: boolean;
 }
 
 export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -132,6 +132,18 @@ export interface GraphQLSchemaValidationOptions {
    * Default: false
    */
   experimentalDefer?: boolean;
+
+  /**
+   *
+   * EXPERIMENTAL:
+   *
+   * If enabled, items from a plural fields with @stream directive
+   * are not returned from the initial query and each item is returned
+   * in a patch after the initial result from the synchronous query.
+   *
+   * Default: false
+   */
+  experimentalStream?: boolean;
 }
 
 export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -182,6 +182,15 @@ export class GraphQLSchema {
       }
     }
 
+    if (config.experimentalStream === true) {
+      this.__experimentalStream = true;
+      if (!this._directives.some((directive) => directive.name === 'stream')) {
+        this._directives = [].concat(this._directives, [
+          GraphQLStreamDirective,
+        ]);
+      }
+    }
+
     // To preserve order of user-provided types, we add first to add them to
     // the set of "collected" types, so `collectReferencedTypes` ignore them.
     const allReferencedTypes: Set<GraphQLNamedType> = new Set(config.types);

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -18,6 +18,7 @@ import {
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLStreamDirective,
   GraphQLDeferDirective,
 } from '../../type/directives';
 import {
@@ -254,12 +255,15 @@ describe('Schema Builder', () => {
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
       directive @defer on FRAGMENT_SPREAD
+      directive @stream on FIELD
     `,
       {
+        experimentalStream: true,
         experimentalDefer: true,
       },
     );
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -271,6 +275,7 @@ describe('Schema Builder', () => {
       GraphQLSpecifiedByDirective,
     );
     expect(schema.getDirective('defer')).to.not.equal(GraphQLDeferDirective);
+    expect(schema.getDirective('stream')).to.not.equal(GraphQLStreamDirective);
   });
 
   it('Adding directives maintains @include, @skip & @specifiedBy', () => {
@@ -285,13 +290,15 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
   });
 
-  it('Adds @defer when experimental flags are passed to schema', () => {
+  it('Adds @defer and @stream when experimental flags are passed to schema', () => {
     const schema = buildSchema('type Query', {
       experimentalDefer: true,
+      experimentalStream: true,
     });
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('defer')).to.equal(GraphQLDeferDirective);
+    expect(schema.getDirective('stream')).to.equal(GraphQLStreamDirective);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
     expect(schema.getDirective('deprecated')).to.equal(

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLIncludeDirective,
   GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
@@ -802,6 +803,7 @@ describe('findBreakingChanges', () => {
         GraphQLSkipDirective,
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
+        GraphQLDeferDirective,
       ],
     });
 

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -5,6 +5,7 @@ import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLIncludeDirective,
   GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
@@ -804,6 +805,7 @@ describe('findBreakingChanges', () => {
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
         GraphQLDeferDirective,
+        GraphQLStreamDirective,
       ],
     });
 

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -10,7 +10,11 @@ import { assertValidSDL } from '../validation/validate';
 
 import type { GraphQLSchemaValidationOptions } from '../type/schema';
 import { GraphQLSchema } from '../type/schema';
-import { specifiedDirectives, GraphQLDeferDirective } from '../type/directives';
+import {
+  specifiedDirectives,
+  GraphQLDeferDirective,
+  GraphQLStreamDirective,
+} from '../type/directives';
 
 import { extendSchemaImpl } from './extendSchema';
 
@@ -109,6 +113,14 @@ export function buildASTSchema(
     directives.push(GraphQLDeferDirective);
   }
 
+  if (
+    options &&
+    options.experimentalStream === true &&
+    !directives.some((directive) => directive.name === 'stream')
+  ) {
+    directives.push(GraphQLStreamDirective);
+  }
+
   return new GraphQLSchema(config);
 }
 
@@ -133,5 +145,6 @@ export function buildSchema(
     assumeValidSDL: options?.assumeValidSDL,
     assumeValid: options?.assumeValid,
     experimentalDefer: options?.experimentalDefer,
+    experimentalStream: options?.experimentalStream,
   });
 }

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -10,7 +10,7 @@ import { assertValidSDL } from '../validation/validate';
 
 import type { GraphQLSchemaValidationOptions } from '../type/schema';
 import { GraphQLSchema } from '../type/schema';
-import { specifiedDirectives } from '../type/directives';
+import { specifiedDirectives, GraphQLDeferDirective } from '../type/directives';
 
 import { extendSchemaImpl } from './extendSchema';
 
@@ -101,6 +101,14 @@ export function buildASTSchema(
     }
   }
 
+  if (
+    options &&
+    options.experimentalDefer === true &&
+    !directives.some((directive) => directive.name === 'defer')
+  ) {
+    directives.push(GraphQLDeferDirective);
+  }
+
   return new GraphQLSchema(config);
 }
 
@@ -124,5 +132,6 @@ export function buildSchema(
     commentDescriptions: options?.commentDescriptions,
     assumeValidSDL: options?.assumeValidSDL,
     assumeValid: options?.assumeValid,
+    experimentalDefer: options?.experimentalDefer,
   });
 }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -232,6 +232,7 @@ export function extendSchemaImpl(
     astNode: schemaDef ?? schemaConfig.astNode,
     extensionASTNodes: schemaConfig.extensionASTNodes.concat(schemaExtensions),
     assumeValid: options?.assumeValid ?? false,
+    experimentalDefer: options?.experimentalDefer ?? false,
   };
 
   // Below are functions used for producing this schema that have closed over

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -233,6 +233,7 @@ export function extendSchemaImpl(
     extensionASTNodes: schemaConfig.extensionASTNodes.concat(schemaExtensions),
     assumeValid: options?.assumeValid ?? false,
     experimentalDefer: options?.experimentalDefer ?? false,
+    experimentalStream: options?.experimentalStream ?? false,
   };
 
   // Below are functions used for producing this schema that have closed over

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
@@ -96,6 +96,137 @@ describe('Validate: Overlapping fields can be merged', () => {
     `);
   });
 
+  it('Same stream directives supported', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectValid(`
+      fragment differentDirectivesWithDifferentAliases on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "streamLabel", initialCount: 1)
+      }
+    `);
+  });
+
+  it('different stream directive label', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "anotherLabel", initialCount: 1)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive initialCount', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "streamLabel", initialCount: 2)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive first missing args', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name @stream(label: "streamLabel", initialCount: 1)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive second missing args', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('mix of stream and no stream', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive both missing args', () => {
+    // @stream is allowed on overlapping fields when they have the same label and
+    // initial count.
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name @stream
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
   it('Same aliases with different field targets', () => {
     expectErrors(`
       fragment sameAliasesWithDifferentFieldTargets on Dog {

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
@@ -12,6 +12,7 @@ import type {
   FieldNode,
   ArgumentNode,
   FragmentDefinitionNode,
+  DirectiveNode,
 } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
@@ -583,6 +584,18 @@ function findConflict(
         [node2],
       ];
     }
+
+    // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
+    const directives1 = node1.directives ?? [];
+    // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
+    const directives2 = node2.directives ?? [];
+    if (!sameStreams(directives1, directives2)) {
+      return [
+        [responseName, 'they have differing stream directives'],
+        [node1],
+        [node2],
+      ];
+    }
   }
 
   // The return type for each field.
@@ -639,6 +652,53 @@ function sameArguments(
     }
     return sameValue(argument1.value, argument2.value);
   });
+}
+
+function sameDirectiveArgument(
+  directive1: DirectiveNode,
+  directive2: DirectiveNode,
+  argumentName: string,
+): boolean {
+  /* istanbul ignore next (See https://github.com/graphql/graphql-js/issues/2203) */
+  const args1 = directive1.arguments || [];
+  const arg1 = find(args1, (argument) => argument.name.value === argumentName);
+  if (!arg1) {
+    return false;
+  }
+
+  /* istanbul ignore next (See https://github.com/graphql/graphql-js/issues/2203) */
+  const args2 = directive2.arguments || [];
+  const arg2 = find(args2, (argument) => argument.name.value === argumentName);
+  if (!arg2) {
+    return false;
+  }
+  return sameValue(arg1.value, arg2.value);
+}
+
+function getStreamDirective(
+  directives: $ReadOnlyArray<DirectiveNode>,
+): ?DirectiveNode {
+  return find(directives, (directive) => directive.name.value === 'stream');
+}
+
+function sameStreams(
+  directives1: $ReadOnlyArray<DirectiveNode>,
+  directives2: $ReadOnlyArray<DirectiveNode>,
+): boolean {
+  const stream1 = getStreamDirective(directives1);
+  const stream2 = getStreamDirective(directives2);
+  if (!stream1 && !stream2) {
+    // both fields do not have streams
+    return true;
+  } else if (stream1 && stream2) {
+    // check if both fields have equivalent streams
+    return (
+      sameDirectiveArgument(stream1, stream2, 'initialCount') &&
+      sameDirectiveArgument(stream1, stream2, 'label')
+    );
+  }
+  // fields have a mix of stream and no stream
+  return false;
 }
 
 function sameValue(value1, value2) {


### PR DESCRIPTION
This allows a resolver to locate itself within the execution tree despite the fact that defer creates branch points in execution per fragment.

This ability is lost were the query to utilize no or conflicting labels for deferred fragments at the same path within the query.

See https://github.com/graphql/graphql-js/pull/2319#issuecomment-666071708